### PR TITLE
Fix Events

### DIFF
--- a/src/xzot1k/plugins/hd/api/events/BasicTeleportationEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/BasicTeleportationEvent.java
@@ -11,13 +11,12 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class BasicTeleportationEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private Location toLocation;
     private Player player;
 
     public BasicTeleportationEvent(Location toLocation, Player player) {
-        handlers = new HandlerList();
         setCancelled(false);
         setToLocation(toLocation);
         setPlayer(player);

--- a/src/xzot1k/plugins/hd/api/events/EconomyChargeEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/EconomyChargeEvent.java
@@ -10,13 +10,12 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class EconomyChargeEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private double amount;
     private Player player;
 
     public EconomyChargeEvent(Player player, double price) {
-        handlers = new HandlerList();
         setCancelled(false);
         setPlayer(player);
         setAmount(price);

--- a/src/xzot1k/plugins/hd/api/events/EconomyReturnEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/EconomyReturnEvent.java
@@ -10,13 +10,12 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class EconomyReturnEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private double amount;
     private OfflinePlayer player;
 
     public EconomyReturnEvent(OfflinePlayer player, double amount) {
-        handlers = new HandlerList();
         setCancelled(false);
         setPlayer(player);
         setAmount(amount);

--- a/src/xzot1k/plugins/hd/api/events/GroupTeleportEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/GroupTeleportEvent.java
@@ -14,14 +14,13 @@ import java.util.List;
 import java.util.UUID;
 
 public class GroupTeleportEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private Location destination;
     private Player groupLeader;
     private List<UUID> groupMemberIds;
 
     public GroupTeleportEvent(Location destination, Player groupLeader, List<UUID> groupMemberIds) {
-        handlers = new HandlerList();
         setCancelled(false);
         setDestination(destination);
         setGroupLeader(groupLeader);

--- a/src/xzot1k/plugins/hd/api/events/MenuOpenEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/MenuOpenEvent.java
@@ -13,7 +13,7 @@ import xzot1k.plugins.hd.HyperDrive;
 import xzot1k.plugins.hd.api.EnumContainer;
 
 public class MenuOpenEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private Inventory openedMenu;
     private EnumContainer.MenuType menuType;
@@ -22,7 +22,6 @@ public class MenuOpenEvent extends Event implements Cancellable {
 
     public MenuOpenEvent(HyperDrive pluginInstance, EnumContainer.MenuType menuType, Inventory openedMenu,
                          Player player) {
-        handlers = new HandlerList();
         setCancelled(false);
         setOpenedMenu(openedMenu);
         setPlayer(player);

--- a/src/xzot1k/plugins/hd/api/events/RandomTeleportEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/RandomTeleportEvent.java
@@ -11,13 +11,12 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class RandomTeleportEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private Location location;
     private Player player;
 
     public RandomTeleportEvent(Location location, Player player) {
-        handlers = new HandlerList();
         setCancelled(false);
         setLocation(location);
         setPlayer(player);

--- a/src/xzot1k/plugins/hd/api/events/WarpEvent.java
+++ b/src/xzot1k/plugins/hd/api/events/WarpEvent.java
@@ -11,13 +11,12 @@ import org.bukkit.event.Event;
 import org.bukkit.event.HandlerList;
 
 public class WarpEvent extends Event implements Cancellable {
-    private static HandlerList handlers;
+    private static HandlerList handlers = new HandlerList();
     private boolean cancelled;
     private Location location;
     private Player player;
 
     public WarpEvent(Location location, Player player) {
-        handlers = new HandlerList();
         setCancelled(false);
         setLocation(location);
         setPlayer(player);


### PR DESCRIPTION
Initialize HandlerList inline because when its used in a listener bukkit isn't going to call the constructor and getHandlerList needs a non-null value